### PR TITLE
skip nil keys instead of segfault

### DIFF
--- a/ext/i18nema/i18nema.c
+++ b/ext/i18nema/i18nema.c
@@ -396,8 +396,9 @@ handle_syck_node(SyckParser *parser, SyckNode *node)
       oid = syck_map_read(node, map_value, i);
       syck_lookup_sym(parser, oid, (void **)&value);
 
-      if (value->type == i_type_null)
+      if (key->type == i_type_null) {
         continue;
+      }
       i_key_value_t *kv = new_key_value(key->data.string, value);
       key->type = i_type_unused; // so we know to free this node in delete_syck_st_entry
       if (value->type == i_type_string)

--- a/ext/i18nema/i18nema.c
+++ b/ext/i18nema/i18nema.c
@@ -396,6 +396,8 @@ handle_syck_node(SyckParser *parser, SyckNode *node)
       oid = syck_map_read(node, map_value, i);
       syck_lookup_sym(parser, oid, (void **)&value);
 
+      if (value->type == i_type_null)
+        continue;
       i_key_value_t *kv = new_key_value(key->data.string, value);
       key->type = i_type_unused; // so we know to free this node in delete_syck_st_entry
       if (value->type == i_type_string)

--- a/test/i18nema_test.rb
+++ b/test/i18nema_test.rb
@@ -94,4 +94,15 @@ class I18nemaTest < Test::Unit::TestCase
     assert_equal %w{asdf asdf asdf},
                  backend.normalize_key(%w{asdf asdf.asdf}, ".")
   end
+
+  def test_skip_nil_keys
+    backend = I18nema::Backend.new
+    syck_nil_key = "--- \n~: \n"
+    psych_nil_key = "---\n! '': \n"
+    result = backend.load_yml_string(syck_nil_key)
+    assert_equal result, 0
+    result = backend.load_yml_string(psych_nil_key)
+    assert_equal result, 0
+  end
+
 end

--- a/test/i18nema_test.rb
+++ b/test/i18nema_test.rb
@@ -99,9 +99,12 @@ class I18nemaTest < Test::Unit::TestCase
     backend = I18nema::Backend.new
     syck_nil_key = "--- \n~: \n"
     psych_nil_key = "---\n! '': \n"
+    syck_nil_key_with_value = "---\n~: value\n"
     result = backend.load_yml_string(syck_nil_key)
     assert_equal result, 0
     result = backend.load_yml_string(psych_nil_key)
+    assert_equal result, 0
+    result = backend.load_yml_string(syck_nil_key_with_value)
     assert_equal result, 0
   end
 


### PR DESCRIPTION
This patch prevents a segfault when processing a yaml file containing an entry with a nil key.
