### PR TITLE
Loosen dependency so newer, working sycks can be used

### DIFF
--- a/i18nema.gemspec
+++ b/i18nema.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.extensions = ['ext/i18nema/extconf.rb']
   s.files = %w(Rakefile README.md) + Dir['ext/**/*.{c,h,rb}'] + Dir['lib/**/*.rb'] + Dir['test/**/*.rb']
-  s.add_dependency('syck', '~> 1.0.0') unless RUBYONEX
+  s.add_dependency('syck', '~> 1.0') unless RUBYONEX
   s.add_dependency('i18n', '>= 0.5')
   s.add_development_dependency('rake-compiler', '~> 0.8.0')
 end


### PR DESCRIPTION
Without this, installation fails with:

```
In file included from ./syck.h:20:
/Users/josh.nichols/.rubies/ruby-2.7.4/include/ruby-2.7.0/ruby/st.h:186:52: error: unknown type name 'VALUE'
void rb_hash_bulk_insert_into_st_table(long, const VALUE *, VALUE);
                                                   ^
/Users/josh.nichols/.rubies/ruby-2.7.4/include/ruby-2.7.0/ruby/st.h:186:61: warning: type specifier missing,
defaults to 'int' [-Wimplicit-int]
void rb_hash_bulk_insert_into_st_table(long, const VALUE *, VALUE);
                                                            ^
1 warning and 1 error generated.
make: *** [gram.o] Error 1

make failed, exit code 2
```

Newer versions of syck are able to compile and install, but there's other issues to using.